### PR TITLE
Uncommenting This containing div (with key) causes errors

### DIFF
--- a/resources/views/components/comment-item.blade.php
+++ b/resources/views/components/comment-item.blade.php
@@ -15,9 +15,9 @@
         <button type="button" x-on:click="show = !show">💬</button>
     </div>
     
-    {{-- <div x-show="show" key="reply-container-{{$nest}}-{{$comment->id}}"> --}}
+    <div x-show="show" key="reply-container-{{$nest}}-{{$comment->id}}">
         <livewire:comment-reply-form :parent_id="$parent_id ?? $comment->id" key="reply-{{$nest}}-{{$comment->id}}"/>
-    {{-- </div> --}}
+    </div>
 
     <ul>
         @foreach ($comment->children as $child)


### PR DESCRIPTION
We have a pretty nested comment structure here: looks like this:

<img width="424" alt="Screenshot 2024-10-22 at 5 19 50 PM" src="https://github.com/user-attachments/assets/6bd82fcb-e53a-4831-9148-440c8c983fd2">

the show/hide of the nested comment forms is done with alpine

```
<li
    wire:key="li-{{$nest}}-{{$comment->id}}"
    x-data="{show:false}"
>
    <div>
        ...
        <button type="button" x-on:click="show = !show">💬</button>
    </div>
    
    <div x-show="show" key="reply-container-{{$nest}}-{{$comment->id}}">
        <livewire:comment-reply-form ... key="reply-{{$nest}}-{{$comment->id}}"/>
    </div>
```

If we add the wrapper div wit `x-show="show"` we get the following if we submit more than one comment from the same form:
<img width="536" alt="Screenshot 2024-10-22 at 5 22 47 PM" src="https://github.com/user-attachments/assets/e0ea75a7-13a7-4bc7-baf4-41c2df79b2cb">



